### PR TITLE
Include VS Code tekton extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
     "redhat.vscode-yaml",
     "redhat.vscode-apache-camel",
     "redhat.vscode-debug-adapter-apache-camel",
-    "redhat.vscode-camelk"
+    "redhat.vscode-camelk",
+    "redhat.vscode-tekton-pipelines"
   ]  
 }


### PR DESCRIPTION
I noticed that there is a Tekton Pipeline file. Depending on what and how you planned to demo the use of it, it might be convenient to have the VS Code Tekton extension https://marketplace.visualstudio.com/items?itemName=redhat.vscode-tekton-pipelines